### PR TITLE
failOnError, failAfterError

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ Type: `object`
 
 This argument has the attribute `jsonlint` wich is an object that contains a `success` boolean attribute. If it's false you also have a `message` attribute containing the jsonlint error message.
 
+### jsonlint.failOnError()
+
+Stop a task/stream if an jsonlint error has been reported for any file.
+
+```javascript
+// Cause the stream to stop(/fail) before copying an invalid JS file to the output directory
+gulp.src('**/*.js')
+	.pipe(jsonlint())
+	.pipe(jsonlint.failOnError())
+	.pipe(gulp.dest('../output'));
+```
+
+### jsonlint.failAfterError()
+
+Stop a task/stream if an jsonlint error has been reported for any file, but wait for all of them to be processed first.
+
 ## License
 
 [MIT License](http://en.wikipedia.org/wiki/MIT_License)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "gulp-util": "^3.0.1",
     "jsonlint": "^1.6.2",
-    "map-stream": "^0.1.0"
+    "map-stream": "^0.1.0",
+    "through2": "^0.6.0"
   },
   "devDependencies": {
     "mocha": "^2.0.0",


### PR DESCRIPTION
I've added two functions, failOnError & failAfterError, through which the gulp pipeline can be redirected after a call to jsonlint()

These will cause gulp to return a non-zero exit code if jsonlint encounters any errors. failOnError will exit the gulp task immediately on encountering a broken file, failAfterError will complete for all files before finishing with an error if any broken files were encountered.

I found this functionality necessary to use gulp-jsonlint with my CI system (Jenkins).